### PR TITLE
support benchmark scripts that need a tty

### DIFF
--- a/bin/baseliner
+++ b/bin/baseliner
@@ -65,6 +65,7 @@ display_skipped_hosts = false
 retry_files_enabled = false
 host_key_checking = false
 callback_whitelist = profile_tasks, timer
+transport = paramiko
 EOL
 
 if [ -n "${ANSIBLE_ROLES_PATH}" ]; then

--- a/tasks/run-script.yml
+++ b/tasks/run-script.yml
@@ -13,6 +13,12 @@
   async: '{{ bench.test_timeout | default(test_timeout | default(6000)) }}'
   poll: 20
   register: script_async
+  when: run_raw is not defined or not run_raw
+
+- name: run script raw
+  raw: '/tmp/{{ bench.script_file }}'
+  register: script_async
+  when: run_raw is defined and run_raw
 
 - name: get output
   async_status:


### PR DESCRIPTION
- Ansible does not deploy a pseudo-tty with the default ssh module
- `raw` gives us the option of deploying a pseudo-tty.
- when conditional uses booleans because `default(True)` is not supported on Ansible 2.4.2

Signed-off-by: Michael Sevilla <michael.sevilla@tidalscale.com>